### PR TITLE
Add workshop check for error code 134

### DIFF
--- a/pysteamcmdwrapper/__init__.py
+++ b/pysteamcmdwrapper/__init__.py
@@ -293,7 +293,7 @@ class SteamCMD():
             # SteamCMD has a habit of timing out large downloads, so if the
             # Validate flag is set, retry on timeout for the remainder of
             # n_tries.
-            if e.returncode == 10 and _validate:
+            if e.returncode == 10:
                 if _validate:
                     self._print_log("Download timeout! Retry due to validate flag")
                     return self.workshop_update(
@@ -309,7 +309,7 @@ class SteamCMD():
             # SteamCMD sometimes crashes when timing out downloads, due to
             # an assert checking that the download actually finished.
             # If this happens, retry if the validate flag is set like above.
-            elif e.returncode == 134 and _validate:
+            elif e.returncode == 134:
                 if _validate:
                     self._print_log("SteamCMD errored! Retry due to validate flag")
                     return self.workshop_update(

--- a/pysteamcmdwrapper/__init__.py
+++ b/pysteamcmdwrapper/__init__.py
@@ -289,7 +289,7 @@ class SteamCMD():
         try:
             return subprocess.check_call(" ".join(e for e in params if e), shell=True)
 
-                except subprocess.CalledProcessError as e:
+        except subprocess.CalledProcessError as e:
             # SteamCMD has a habit of timing out large downloads, so if the
             # Validate flag is set, retry on timeout for the remainder of
             # n_tries.


### PR DESCRIPTION
There seemingly is an assert that checks if the entirety of a workshop item downloaded. This will cause it to exit with error code 134 on large downloads, where it only succeeds in downloading a part of it at a time before timing out. Repeating it multiple times allows it to eventually finish, the amount of times depending on the size of the download.

This pull request makes it check for SteamCMD error 134, and retry if the validate flag is set, the same way return code 10 is handled.